### PR TITLE
Updating pylint rc file to work with newer versions of pylint

### DIFF
--- a/pylint.rc
+++ b/pylint.rc
@@ -58,6 +58,8 @@ load-plugins=
 # Disable the message(s) with the given id(s).
 disable-msg=W0141,W0142,W0401,W0403,W0511,W0603,W0614,W0611,W0702,W0703,W0704,W0706,C0111,C0112,C0301,C0302
 
+# Newer pylint versions use key 'disable' rather than 'disable-msg'
+disable=W0141,W0142,W0401,W0403,W0511,W0603,W0614,W0611,W0702,W0703,W0704,W6501,C0111,C0112,C0301,C0302,E1120,F0401
 
 [REPORTS]
 


### PR DESCRIPTION
The pylint rc file does not work correctly with newer versions of pylint. The 'disable-msg' key has been modified to be 'disable' in the new versions of pylint.

Leaving both lines in the file to make sure we don't brake anything whilst transitioning over to building in a Centos 6.4 chroot.

Signed-off-by: Rob Dobson rob@rdobson.co.uk
