### PR TITLE
CA-97307: recover from the TVM disk being deleted

### DIFF
--- a/supp-pack/uninstall-transfer-vm.sh
+++ b/supp-pack/uninstall-transfer-vm.sh
@@ -28,6 +28,14 @@ template_uuids=$(xe template-list --minimal other-config:transfervm=true)
 
 for template in $template_uuids; do
    vbd=$(xe vbd-list --minimal vm-uuid=$template)
+
+   # Remove detached templates
+   if [ -z $vbd ]
+   then
+       xe template-uninstall template-uuid=$template force=true
+       continue
+   fi
+
    echo "VBD = $vbd"
    vdi=$(xe vbd-param-get uuid=$vbd param-name=vdi-uuid)
    echo "VDI = $vdi"

--- a/transferplugin/transfer
+++ b/transferplugin/transfer
@@ -1776,6 +1776,15 @@ def get_local_transfer_vm_template(session, this_host):
     template, _ = find_local_template(session, transfer_templates, this_host)
     return template
 
+def _get_vm_vbds(session, template):
+    vbd_recs = session.xenapi.VBD.get_all_records()
+    refs = []
+    for vbd_ref, vbd_rec in vbd_recs.iteritems():
+        # Check if the VBD belongs to the VM in question
+        if vbd_rec['VM'] == template:
+            refs.append(vbd_ref)
+    return refs
+
 def prepare_transfervm_template(session, args):
     logging.debug(args) #Work around for pylint checking
     host_uuid = get_from_xensource_inventory('INSTALLATION_UUID')
@@ -1787,7 +1796,10 @@ def prepare_transfervm_template(session, args):
 
     template = get_local_transfer_vm_template(session, this_host)
 
-    if ( (has_rpm_state_changed() != True) and (template is not None)):
+    # Make sure the templates disks have not been removed
+    vbds = _get_vm_vbds(session, template)
+
+    if ( (has_rpm_state_changed() != True) and (template is not None) and vbds):
         return template
     else:
         install_transfer_vm_template()


### PR DESCRIPTION
Currently, when we need to expose a VM disk image, we check to see if the TVM template has been installed. If it hasn't been installed, then we go ahead and import the new image. If however, the template exists, but no longer has any VBDs (perhaps the user has deleted the VDI), then we do not re-import the TVM.

This patch set fixes that problem, and checks the template has VBDs - if it doesn't - then it goes ahead and installs a new template (cleaning up the stale one).

Signed-off-by: Rob Dobson rob@rdobson.co.uk
