### PR TITLE
CP-10670: Swap to using a standalone xenstore binary to avoid linking

### DIFF
--- a/transfervm/Makefile
+++ b/transfervm/Makefile
@@ -77,9 +77,9 @@ ISCSITARGET_SOURCE_STAMP := $(MY_OBJ_DIR)/.iscsitarget.source.stamp
 ISCSITARGET_BUILD_STAMP := $(MY_OBJ_DIR)/.iscsitarget.build.stamp
 
 PULLER_SOURCE_STAMP := $(MY_OBJ_DIR)/.puller.source.stamp
+XENSTORE_SOURCE_STAMP := $(MY_OBJ_DIR)/.xenstore.source.stamp
 
 MODULES_STAMP := $(MY_OBJ_DIR)/.modules.stamp
-XENSTORE_STAMP := $(MY_OBJ_DIR)/.xenstore.stamp
 
 OVERLAY_STAMP := $(MY_OBJ_DIR)/.overlay.stamp
 
@@ -93,6 +93,7 @@ MAKE_SOURCES := $(REPO)/transfervm/make-sources.sh
 OVERLAY := $(REPO)/transfervm/overlay
 
 PULLER_DIR := $(REPO)/transfervm/puller
+XENSTORE_DIR := $(REPO)/transfervm/xenstore
 
 # Output targets
 KERNEL := $(MY_OUTPUT_DIR)/vmlinuz
@@ -132,7 +133,7 @@ $(INITRD): $(INITRD_STAGING_STAMP)
 	| $(FAKEROOT) cpio --quiet -o -Hnewc \
 	| gzip -v9 >$@.tmp && mv $@.tmp $@
 
-$(INITRD_STAGING_STAMP): $(BUILDROOT_STAMP) $(ISCSITARGET_STAMP) $(MODULES_STAMP) $(XENSTORE_STAMP) $(OVERLAY_STAMP)
+$(INITRD_STAGING_STAMP): $(BUILDROOT_STAMP) $(ISCSITARGET_STAMP) $(MODULES_STAMP) $(OVERLAY_STAMP)
 	# Create the filesystem tree (each dependency installs itself)
 	touch $@
 
@@ -144,7 +145,7 @@ $(BUILDROOT_STAMP): $(BUILDROOT_BUILD_STAMP) $(LIGHTTPD_BUILD_STAMP)
 	rm -rf .subversion
 	touch $@
 
-$(BUILDROOT_BUILD_STAMP): $(BUILDROOT_SOURCE_STAMP) $(PULLER_SOURCE_STAMP)
+$(BUILDROOT_BUILD_STAMP): $(BUILDROOT_SOURCE_STAMP) $(PULLER_SOURCE_STAMP) $(XENSTORE_SOURCE_STAMP)
 	# Buildroot compilation.
 	$(BUILDROOT_MAKE)
 	touch $@
@@ -154,7 +155,9 @@ $(BUILDROOT_SOURCE_STAMP): $(BUILDROOT_SOURCE) buildroot.config
 	tar -C $(MY_OBJ_DIR) -xvzf $(BUILDROOT_SOURCE)
 	cp $(REPO)/transfervm/buildroot.config $(BUILDROOT_DIR)/.config
 	patch -d $(BUILDROOT_DIR) -p0 <$(PULLER_DIR)/buildroot.patch
+	patch -d $(BUILDROOT_DIR) -p0 <$(XENSTORE_DIR)/buildroot.patch
 	rsync -av $(PULLER_DIR)/package/ $(BUILDROOT_DIR)/package/
+	rsync -av $(XENSTORE_DIR)/package/ $(BUILDROOT_DIR)/package/
 	if [ "$(MY_OUTPUT_DIR)" = "/tmp/transfervm-output" ]; \
 	then \
 		patch $(BUILDROOT_DIR)/.config <buildroot.config.patch; \
@@ -240,18 +243,20 @@ $(PULLER_SOURCE_STAMP): $(BUILDROOT_SOURCE_STAMP) $(PULLER_DIR)/Makefile \
 	rm -rf $(BUILDROOT_DIR)/build_i686/puller
 	touch $@
 
+$(XENSTORE_SOURCE_STAMP): $(BUILDROOT_SOURCE_STAMP) $(XENSTORE_DIR)/Makefile \
+			$(wildcard $(XENSTORE_DIR)/*.[ch])
+	mkdir -p $(MY_OBJ_DIR)/xenstore
+	cp $^ $(MY_OBJ_DIR)/xenstore
+	rm -rf $(BUILDROOT_DIR)/build_i686/xenstore
+	touch $@
+
 $(MODULES_STAMP): $(PROJECT_OUTPUTDIR)/kernel-iscsitarget/$(MODULES_FILENAME)
 	tar -C $(INITRD_STAGING_DIR) -xjf $(PROJECT_OUTPUTDIR)/kernel-iscsitarget/$(MODULES_FILENAME)
 	/sbin/depmod -b $(INITRD_STAGING_DIR) $(KERNEL_VERSION)
 	touch $@
 
-$(XENSTORE_STAMP): $(PROJECT_OUTPUTDIR)/uclibc-xen/uclibc-binaries.tar.bz2
-	mkdir -p $(INITRD_STAGING_DIR)/usr/bin/
-	tar --wildcards --extract --bzip2 --file $< --directory $(INITRD_STAGING_DIR) ./usr/bin/xenstore\*
-	touch $@
-
 # Overlay should be the last thing to be added to the INITRD_STAGING_DIR
-$(OVERLAY_STAMP): $(BUILDROOT_STAMP) $(ISCSITARGET_STAMP) $(XENSTORE_STAMP) $(MODULES_STAMP) $(shell find $(OVERLAY) -type f)
+$(OVERLAY_STAMP): $(BUILDROOT_STAMP) $(ISCSITARGET_STAMP) $(MODULES_STAMP) $(shell find $(OVERLAY) -type f)
 	cp -R $(OVERLAY)/* $(INITRD_STAGING_DIR)
 	$(call brand, $(OVERLAY)/etc/init.d/S60xenapiversion) >$(INITRD_STAGING_DIR)/etc/init.d/S60xenapiversion
 	touch $@

--- a/transfervm/buildroot.config
+++ b/transfervm/buildroot.config
@@ -668,6 +668,7 @@ BR2_PACKAGE_ZLIB=y
 # Transfer VM packages
 #
 BR2_PACKAGE_PULLER=y
+BR2_PACKAGE_XENSTORE=y
 
 #
 # Target filesystem options

--- a/transfervm/xenstore/Makefile
+++ b/transfervm/xenstore/Makefile
@@ -1,0 +1,12 @@
+CFLAGS += -Wall -Werror
+ROOTDIR := ../../project_build_i686/transfervm/root
+
+xenstore-compat: xenstore-compat.o
+
+.PHONY: install
+install:
+	cp -p xenstore-compat ${ROOTDIR}/usr/bin/xenstore
+	ln -sf xenstore ${ROOTDIR}/usr/bin/xenstore-read
+	ln -sf xenstore ${ROOTDIR}/usr/bin/xenstore-write
+	ln -sf xenstore ${ROOTDIR}/usr/bin/xenstore-exists
+	ln -sf xenstore ${ROOTDIR}/usr/bin/xenstore-rm

--- a/transfervm/xenstore/buildroot.patch
+++ b/transfervm/xenstore/buildroot.patch
@@ -1,0 +1,12 @@
+--- package/Config.in	2010-05-27 18:37:07.000000000 +0100
++++ package/Config.in	2010-05-27 18:37:54.000000000 +0100
+@@ -4,8 +4,9 @@
+ 
+ comment "The minimum needed to build a uClibc development system"
+ 
++source "package/xenstore/Config.in"
+ source "package/puller/Config.in"
+ 
+ if !BR2_PACKAGE_BUSYBOX_HIDE_OTHERS
+ source "package/bash/Config.in"
+ source "package/bzip2/Config.in"

--- a/transfervm/xenstore/package/xenstore/Config.in
+++ b/transfervm/xenstore/package/xenstore/Config.in
@@ -1,0 +1,4 @@
+config BR2_PACKAGE_XENSTORE
+        bool "xenstore"
+        help
+	  Minimal Xenstore client

--- a/transfervm/xenstore/package/xenstore/xenstore.mk
+++ b/transfervm/xenstore/package/xenstore/xenstore.mk
@@ -1,0 +1,46 @@
+#############################################################
+#
+# xenstore
+#
+#############################################################
+XENSTORE_VERSION:=1
+XENSTORE_SOURCE:=xenstore.tar.gz
+XENSTORE_SITE:=
+XENSTORE_DIR:=$(BUILD_DIR)/xenstore
+XENSTORE_BINARY:=xenstore
+XENSTORE_TARGET_BINARY:=usr/bin/xenstore
+
+$(eval $(call AUTOTARGETS,package,foo))
+
+$(XENSTORE_DIR)/.source:
+	rsync -av /obj/xenstore/ $(XENSTORE_DIR)
+	touch $@
+
+$(XENSTORE_DIR)/.configured: $(XENSTORE_DIR)/.source
+	touch $@
+
+$(XENSTORE_DIR)/$(XENSTORE_BINARY): $(XENSTORE_DIR)/.configured
+	$(MAKE) $(TARGET_CONFIGURE_ARGS) $(TARGET_CONFIGURE_OPTS) -C $(XENSTORE_DIR)
+
+$(TARGET_DIR)/$(XENSTORE_TARGET_BINARY): $(XENSTORE_DIR)/$(XENSTORE_BINARY)
+	$(MAKE) -C $(XENSTORE_DIR) install
+
+xenstore: $(TARGET_DIR)/$(XENSTORE_TARGET_BINARY)
+
+xenstore-source:
+
+xenstore-clean:
+	$(MAKE) -C $(XENSTORE_DIR) uninstall
+	-$(MAKE) -C $(XENSTORE_DIR) clean
+
+xenstore-dirclean:
+	rm -rf $(XENSTORE_DIR)
+
+#############################################################
+#
+# Toplevel Makefile options
+#
+#############################################################
+ifeq ($(BR2_PACKAGE_XENSTORE),y)
+TARGETS+=xenstore
+endif

--- a/transfervm/xenstore/xenstore-compat.c
+++ b/transfervm/xenstore/xenstore-compat.c
@@ -1,0 +1,249 @@
+/* Transfer VM - VPX for exposing VDIs on XenServer 
+ * Copyright (C) Citrix Systems, Inc.
+ * 
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <fcntl.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "xs_wire.h"
+
+#define XEN_PATH "/proc/xen"
+#define XENBUS_PATH XEN_PATH"/xenbus"
+
+#ifndef min
+#define min(a, b) (((a) < (b)) ? (a) : (b))
+#endif
+
+enum mode {
+  M_INVALID,
+  M_READ,
+  M_WRITE,
+  M_EXISTS,
+  M_RM
+};
+
+static uint32_t req_id = 0;
+
+/*
+ * stripped down xenstore read
+ */
+char *xenstore_read(int fd, const char *key)
+{
+  struct xsd_sockmsg msg = { XS_READ };
+  char buffer[XENSTORE_PAYLOAD_MAX];
+  ssize_t len;
+
+  msg.req_id = req_id++;
+  /* payload is key, NUL */
+  msg.len = strlen(key) + 1;
+  if (write(fd, &msg, sizeof(msg)) != sizeof(msg))
+    return NULL;
+  write(fd, key, strlen(key) + 1);
+
+  /* read response */
+  if (read(fd, &msg, sizeof(msg)) != sizeof(msg))
+    return NULL;
+  if (msg.len) {
+    len = read(fd, buffer, min(msg.len, XENSTORE_PAYLOAD_MAX));
+    if (len == -1)
+      return NULL;
+  }
+  if (msg.type != XS_READ)
+    return NULL;
+
+  return strdup(buffer);
+}
+
+/*
+ * stripped down xenstore write
+ */
+int xenstore_write(int fd, const char *key, const char *value)
+{
+  struct xsd_sockmsg msg = { XS_WRITE };
+  char buffer[8];
+  int ret = 0;
+
+  msg.req_id = req_id++;
+  /* payload is key, NUL, value */
+  msg.len = strlen(key) + strlen(value) + 1;
+  if (write(fd, &msg, sizeof(msg)) != sizeof(msg))
+    return 1;
+  write(fd, key, strlen(key) + 1);
+  write(fd, value, strlen(value));
+
+  /* read and discard response */
+  if (read(fd, &msg, sizeof(msg)) != sizeof(msg))
+    return 1;
+  while (msg.len) {
+    ssize_t len = read(fd, buffer, min(msg.len, sizeof(buffer)));
+
+    if (len < 1)
+      break;
+    msg.len -= len;
+  }
+  if (msg.type != XS_WRITE)
+    ret = 1;
+
+  return ret;
+}
+
+/*
+ * stripped down xenstore rm
+ */
+int xenstore_rm(int fd, const char *key)
+{
+  struct xsd_sockmsg msg = { XS_RM };
+  char buffer[8];
+  int ret = 0;
+
+  msg.req_id = req_id++;
+  /* payload is key, NUL */
+  msg.len = strlen(key) + 1;
+  if (write(fd, &msg, sizeof(msg)) != sizeof(msg))
+    return 1;
+  write(fd, key, strlen(key) + 1);
+
+  /* read and discard response */
+  if (read(fd, &msg, sizeof(msg)) != sizeof(msg))
+    return 1;
+  while (msg.len) {
+    ssize_t len = read(fd, buffer, min(msg.len, sizeof(buffer)));
+
+    if (len < 1)
+      break;
+    msg.len -= len;
+  }
+  if (msg.type != XS_RM)
+    ret = 1;
+
+  return ret;
+}
+
+void usage(void)
+{
+  fprintf(stderr, "Usage: xenstore [read|write|exists|rm] ...\n");
+  exit(1);
+}
+
+enum mode get_mode(const char *str)
+{
+  if (strcmp(str, "read") == 0)
+    return M_READ;
+  if (strcmp(str, "write") == 0)
+    return M_WRITE;
+  if (strcmp(str, "exists") == 0)
+    return M_EXISTS;
+  if (strcmp(str, "rm") == 0)
+    return M_RM;
+  return M_INVALID;
+}
+
+int read_cmd(int fd, const char *key)
+{
+  char *value;
+  char *p;
+
+  value = xenstore_read(fd, key);
+  if (value == NULL)
+    return 1;
+
+  /* escape control characters for shell */
+  for (p = value; *p; p++)
+    if (*p >= ' ' && *p <= '~' && *p != '\\')
+      putchar(*p);
+    else {
+      putchar('\\');
+      switch (*p) {
+      case '\t': putchar('t'); break;
+      case '\n': putchar('n'); break;
+      case '\r': putchar('r'); break;
+      case '\\': putchar('\\'); break;
+      default:
+	if (*p < 010)
+	  printf("%03o", *p);
+	else
+	  printf("x%02x", *p);
+      }
+    }
+  putchar('\n');
+  free(value);
+  
+  return 0;
+}
+
+int main(int argc, char **argv)
+{
+  char *mode_p;
+  char *p;
+  unsigned arg_ind = 1;
+  int ret = 0;
+  int fd;
+
+  /* determine mode and argument position */
+  p = strrchr(argv[0], '/');
+  if (p)
+    p++;
+  else
+    p = argv[0];
+  if (strncmp(p, "xenstore-", 9) == 0) {
+    mode_p = p + 9;
+  }
+  else {
+    if (argc < 2)
+      usage();
+    mode_p = argv[1];
+    arg_ind = 2;
+  }
+
+  /* all modes need at least one argument */
+  if (arg_ind + 1 > argc)
+    usage();
+
+  fd = open(XENBUS_PATH, O_RDWR);
+
+  switch (get_mode(mode_p)) {
+  case M_READ:
+    ret = read_cmd(fd, argv[arg_ind]);
+    break;
+  case M_WRITE:
+    /* write needs two arguments */
+    if (arg_ind + 2 > argc)
+      usage();
+    ret = xenstore_write(fd, argv[arg_ind], argv[arg_ind+1]);
+    break;
+  case M_EXISTS:
+    p = xenstore_read(fd, argv[arg_ind]);
+    if (p)
+      free(p);
+    else
+      ret = 1;
+    break;
+  case M_RM:
+    ret = xenstore_rm(fd, argv[arg_ind]);
+    break;
+  default:
+    usage();
+  }
+
+  close(fd);
+
+  return ret;
+}

--- a/transfervm/xenstore/xs_wire.h
+++ b/transfervm/xenstore/xs_wire.h
@@ -1,0 +1,143 @@
+/*
+ * Details of the "wire" protocol between Xen Store Daemon and client
+ * library or guest kernel.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *
+ * Copyright (C) 2005 Rusty Russell IBM Corporation
+ */
+
+#ifndef _XS_WIRE_H
+#define _XS_WIRE_H
+
+enum xsd_sockmsg_type
+{
+    XS_DEBUG,
+    XS_DIRECTORY,
+    XS_READ,
+    XS_GET_PERMS,
+    XS_WATCH,
+    XS_UNWATCH,
+    XS_TRANSACTION_START,
+    XS_TRANSACTION_END,
+    XS_INTRODUCE,
+    XS_RELEASE,
+    XS_GET_DOMAIN_PATH,
+    XS_WRITE,
+    XS_MKDIR,
+    XS_RM,
+    XS_SET_PERMS,
+    XS_WATCH_EVENT,
+    XS_ERROR,
+    XS_IS_DOMAIN_INTRODUCED,
+    XS_RESUME,
+    XS_SET_TARGET,
+    XS_RESTRICT,
+    XS_RESET_WATCHES
+};
+
+#define XS_WRITE_NONE "NONE"
+#define XS_WRITE_CREATE "CREATE"
+#define XS_WRITE_CREATE_EXCL "CREATE|EXCL"
+
+/* We hand errors as strings, for portability. */
+struct xsd_errors
+{
+    int errnum;
+    const char *errstring;
+};
+#ifdef EINVAL
+#define XSD_ERROR(x) { x, #x }
+/* LINTED: static unused */
+static struct xsd_errors xsd_errors[]
+#if defined(__GNUC__)
+__attribute__((unused))
+#endif
+    = {
+    XSD_ERROR(EINVAL),
+    XSD_ERROR(EACCES),
+    XSD_ERROR(EEXIST),
+    XSD_ERROR(EISDIR),
+    XSD_ERROR(ENOENT),
+    XSD_ERROR(ENOMEM),
+    XSD_ERROR(ENOSPC),
+    XSD_ERROR(EIO),
+    XSD_ERROR(ENOTEMPTY),
+    XSD_ERROR(ENOSYS),
+    XSD_ERROR(EROFS),
+    XSD_ERROR(EBUSY),
+    XSD_ERROR(EAGAIN),
+    XSD_ERROR(EISCONN),
+    XSD_ERROR(E2BIG)
+};
+#endif
+
+struct xsd_sockmsg
+{
+    uint32_t type;  /* XS_??? */
+    uint32_t req_id;/* Request identifier, echoed in daemon's response.  */
+    uint32_t tx_id; /* Transaction id (0 if not related to a transaction). */
+    uint32_t len;   /* Length of data following this. */
+
+    /* Generally followed by nul-terminated string(s). */
+};
+
+enum xs_watch_type
+{
+    XS_WATCH_PATH = 0,
+    XS_WATCH_TOKEN
+};
+
+/*
+ * `incontents 150 xenstore_struct XenStore wire protocol.
+ *
+ * Inter-domain shared memory communications. */
+
+#define XENSTORE_RING_SIZE 1024
+typedef uint32_t XENSTORE_RING_IDX;
+#define MASK_XENSTORE_IDX(idx) ((idx) & (XENSTORE_RING_SIZE-1))
+struct xenstore_domain_interface {
+    /* XENSTORE_VERSION_0 */
+    char req[XENSTORE_RING_SIZE]; /* Requests to xenstore daemon. */
+    char rsp[XENSTORE_RING_SIZE]; /* Replies and async watch events. */
+    XENSTORE_RING_IDX req_cons, req_prod;
+    XENSTORE_RING_IDX rsp_cons, rsp_prod;
+    uint32_t server_version;
+    /* server_version 1 and later: */
+    uint32_t closing;             /* Non-zero means close in progress */
+};
+
+/* Violating this is very bad.  See docs/misc/xenstore.txt. */
+#define XENSTORE_PAYLOAD_MAX 4096
+
+/* Violating these just gets you an error back */
+#define XENSTORE_ABS_PATH_MAX 3072
+#define XENSTORE_REL_PATH_MAX 2048
+
+#endif /* _XS_WIRE_H */
+
+/*
+ * Local variables:
+ * mode: C
+ * c-file-style: "BSD"
+ * c-basic-offset: 4
+ * tab-width: 4
+ * indent-tabs-mode: nil
+ * End:
+ */


### PR DESCRIPTION
against libxenstore.so. This removes the dependcy on the uclibc-xen
build target.

Reviewed-by: Rob Dobson <rob.dobson@citrix.com>
Reviewed-by: Andrew Cooper <andrew.cooper3@citrix.com>
Signed-off-by: Simon Rowe <simon.rowe@citrix.com>