### PR TITLE
CA-330736: Transfer VM use plain text credential

### DIFF
--- a/transfervm/overlay/sbin/hotplug.lighttpd
+++ b/transfervm/overlay/sbin/hotplug.lighttpd
@@ -45,7 +45,7 @@ EOF
 auth.debug = 2
 auth.backend = "plain"
 auth.backend.plain.userfile = "$authfile"
-auth.require = ("" => ("method" => "basic", "realm" => "Transfer VM", "require" => "valid-user"))
+auth.require = ("" => ("method" => "digest", "realm" => "Transfer VM", "require" => "valid-user"))
 EOF
     fi
 


### PR DESCRIPTION
Transfer VM will start up for each VM export. A HTTP service will be
started to retrieve the data of virtual disk from this VM. A credential
is configued to protect the service. The credential is just a user name
and password. Both of them are generated randomly.

The issue is this credential is equipped as HTTP basic authentication
approach, which means the clear text of password could be seen publicly
in HTTP request.

This commit is to change the HTTP authentication approach from basic to
digest, which could improve the security.

Signed-off-by: Ming Lu <ming.lu@citrix.com>